### PR TITLE
feat: Add bulk telemetry for blog post summaries

### DIFF
--- a/generate.go
+++ b/generate.go
@@ -340,6 +340,7 @@ func generateIndex(gc *GenerationContext, lang types.Lang) error {
 			Description: pm.Description,
 			Date:        pm.Date,
 			URL:         postPath,
+			Path:        post.Path,
 		})
 	}
 

--- a/public/main.css
+++ b/public/main.css
@@ -1202,6 +1202,10 @@ video {
   margin-top: 0.5rem;
 }
 
+.mt-4 {
+  margin-top: 1rem;
+}
+
 .mt-6 {
   margin-top: 1.5rem;
 }

--- a/public/main.js
+++ b/public/main.js
@@ -599,12 +599,20 @@ async function initTelemetry() {
     } catch (error) {
         console.error("Telemetry initialization failed:", error);
     }
-    // Ensure hydrateCounts runs after telemetry (and its recordView calls) finish,
+    // Ensure hydrateCounts and hydrateSummaryCounts run after telemetry (and its recordView calls) finish,
     // and only once the DOM is ready.
+    const runHydrations = () => {
+        try {
+            hydrateCounts();
+        } catch (e) { console.error("hydrateCounts failed:", e); }
+        try {
+            hydrateSummaryCounts();
+        } catch (e) { console.error("hydrateSummaryCounts failed:", e); }
+    };
     if (document.readyState === 'loading') {
-        document.addEventListener('DOMContentLoaded', hydrateCounts, { once: true });
+        document.addEventListener('DOMContentLoaded', runHydrations, { once: true });
     } else {
-        hydrateCounts();
+        runHydrations();
     }
 }
 
@@ -676,9 +684,107 @@ async function hydrateCounts() {
 }
 
 
+/**
+ * Hydrate summary counts for index/list pages using bulk lookup. Uses data-summary-url,
+ * data-summary-view-count, and data-summary-like-count. Completely separate from per-page
+ * hydration logic.
+ */
+async function hydrateSummaryCounts() {
+    if (isCrawler()) return;
+    // Collect URLs from summary placeholders
+    const summaryEls = Array.from(document.querySelectorAll('[data-summary-url]'));
+    if (summaryEls.length === 0) return;
+    const urls = summaryEls
+        .map(el => el.getAttribute('data-summary-url'))
+        .filter(Boolean);
+    const uniqueUrls = [...new Set(urls)];
+    // Keep placeholders while fetching
+    for (const el of document.querySelectorAll('[data-summary-view-count]')) {
+        el.textContent = 'views ...';
+    }
+    for (const el of document.querySelectorAll('[data-summary-like-count]')) {
+        el.textContent = 'likes ...';
+    }
+    try {
+        const bulk = await getBulkCounts(uniqueUrls);
+        if (!bulk || !bulk.map) return;
+        const map = bulk.map;
+        // Update view placeholders
+        const viewEls = document.querySelectorAll('[data-summary-view-count]');
+        for (const el of viewEls) {
+            const url = el.getAttribute('data-summary-url');
+            if (!url) continue;
+            const entry = map[url];
+            const count = (entry && typeof entry.view_count !== 'undefined') ? entry.view_count : 0;
+            el.textContent = `views ${count}`;
+        }
+        // Update like placeholders
+        const likeEls = document.querySelectorAll('[data-summary-like-count]');
+        for (const el of likeEls) {
+            const url = el.getAttribute('data-summary-url');
+            if (!url) continue;
+            const entry = map[url];
+            const count = (entry && typeof entry.like_count !== 'undefined') ? entry.like_count : 0;
+            el.textContent = `likes ${count}`;
+        }
+    } catch (e) {
+        console.error("hydrateSummaryCounts failed:", e);
+        for (const el of document.querySelectorAll('[data-summary-view-count]')) {
+            el.textContent = 'views 0';
+        }
+        for (const el of document.querySelectorAll('[data-summary-like-count]')) {
+            el.textContent = 'likes 0';
+        }
+    }
+}
+
+/**
+ * Performs a bulk counts lookup for multiple URLs.
+ * POST /counts/bulk expects JSON body: { "urls": ["https://...", ...] }
+ * Returns an object with the raw server response and a convenience map keyed by normalized URL:
+ *   { raw: { results: [...] }, map: { "https://...": { view_count, like_count }, ... } }
+ * or null on error.
+ * @param {string[]} urls
+ * @returns {Promise<Object|null>}
+ */
+async function getBulkCounts(urls = []) {
+    if (!Array.isArray(urls) || urls.length === 0) {
+        console.warn("getBulkCounts: expected a non-empty array of urls");
+        return { raw: { results: [] }, map: {} };
+    }
+ 
+    try {
+        const resp = await fetch(TELEMETRY_BASEURL + "/counts/bulk", {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+            },
+            body: JSON.stringify({ urls: urls }),
+        });
+ 
+        if (resp.status === 200) {
+            const data = await resp.json();
+            const map = {};
+            if (Array.isArray(data.results)) {
+                for (const e of data.results) {
+                    map[e.url] = { view_count: e.view_count, like_count: e.like_count };
+                }
+            }
+            return { raw: data, map: map };
+        } else {
+            console.error("Failed to get bulk counts. Status:", resp.status);
+            return null;
+        }
+    } catch (error) {
+        console.error("Error getting bulk counts:", error);
+        return null;
+    }
+}
+
 // Make functions available globally for manual use
 window.recordView = recordView;
 window.getViewCount = getViewCount;
 window.recordViewAndGetCount = recordViewAndGetCount;
 window.recordLike = recordLike;
 window.getLikeCount = getLikeCount;
+window.getBulkCounts = getBulkCounts;

--- a/view/component_blog_post.templ
+++ b/view/component_blog_post.templ
@@ -8,6 +8,7 @@ type BlogPostPreview struct {
 	Description string
 	Date        time.Time
 	URL         string
+	Path        string
 }
 
 templ BlogPostCard(post *BlogPostPreview) {
@@ -22,6 +23,11 @@ templ BlogPostCard(post *BlogPostPreview) {
 			</div>
 			<h2 class="text-xl font-bold mb-2">{ post.Title }</h2>
 			<p class="text-m font-weight-300">{ post.Description }</p>
+			<div class="mt-4 flex items-center text-sm text-gray-500 gap-4">
+				<!-- Summary placeholders for index list (separate from post page) -->
+				<span data-summary-view-count data-summary-url={ templ.SafeURL("https://gosuda.org" + post.Path) } aria-label="View count">views ...</span>
+				<span data-summary-like-count data-summary-url={ templ.SafeURL("https://gosuda.org" + post.Path) } aria-label="Like count">likes ...</span>
+			</div>
 		</div>
 	</a>
 }

--- a/view/component_blog_post_templ.go
+++ b/view/component_blog_post_templ.go
@@ -16,6 +16,7 @@ type BlogPostPreview struct {
 	Description string
 	Date        time.Time
 	URL         string
+	Path        string
 }
 
 func BlogPostCard(post *BlogPostPreview) templ.Component {
@@ -46,7 +47,7 @@ func BlogPostCard(post *BlogPostPreview) templ.Component {
 		var templ_7745c5c3_Var2 templ.SafeURL
 		templ_7745c5c3_Var2, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(post.URL))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `view/component_blog_post.templ`, Line: 14, Col: 139}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `view/component_blog_post.templ`, Line: 15, Col: 139}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var2))
 		if templ_7745c5c3_Err != nil {
@@ -59,7 +60,7 @@ func BlogPostCard(post *BlogPostPreview) templ.Component {
 		var templ_7745c5c3_Var3 string
 		templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinStringErrs(post.Author)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `view/component_blog_post.templ`, Line: 19, Col: 45}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `view/component_blog_post.templ`, Line: 20, Col: 45}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var3))
 		if templ_7745c5c3_Err != nil {
@@ -72,7 +73,7 @@ func BlogPostCard(post *BlogPostPreview) templ.Component {
 		var templ_7745c5c3_Var4 string
 		templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinStringErrs(post.Date.Format("January 2, 2006"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `view/component_blog_post.templ`, Line: 20, Col: 77}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `view/component_blog_post.templ`, Line: 21, Col: 77}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
 		if templ_7745c5c3_Err != nil {
@@ -85,7 +86,7 @@ func BlogPostCard(post *BlogPostPreview) templ.Component {
 		var templ_7745c5c3_Var5 string
 		templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs(post.Title)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `view/component_blog_post.templ`, Line: 23, Col: 50}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `view/component_blog_post.templ`, Line: 24, Col: 50}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
 		if templ_7745c5c3_Err != nil {
@@ -98,13 +99,39 @@ func BlogPostCard(post *BlogPostPreview) templ.Component {
 		var templ_7745c5c3_Var6 string
 		templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinStringErrs(post.Description)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `view/component_blog_post.templ`, Line: 24, Col: 55}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `view/component_blog_post.templ`, Line: 25, Col: 55}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var6))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "</p></div></a>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "</p><div class=\"mt-4 flex items-center text-sm text-gray-500 gap-4\"><!-- Summary placeholders for index list (separate from post page) --><span data-summary-view-count data-summary-url=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var7 string
+		templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(templ.SafeURL("https://gosuda.org" + post.Path))
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `view/component_blog_post.templ`, Line: 28, Col: 100}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "\" aria-label=\"View count\">views ...</span> <span data-summary-like-count data-summary-url=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var8 string
+		templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs(templ.SafeURL("https://gosuda.org" + post.Path))
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `view/component_blog_post.templ`, Line: 29, Col: 100}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "\" aria-label=\"Like count\">likes ...</span></div></div></a>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}


### PR DESCRIPTION
This commit introduces bulk telemetry lookup for blog post summaries on index and list pages.

- **`generate.go`**: Now includes the `Path` in `PostSummary` to facilitate URL lookup for telemetry.
- **`public/main.css`**: Adds a new `mt-4` utility class for margin-top.
- **`public/main.js`**:
    - Implements `hydrateSummaryCounts` to fetch and display view and like counts for multiple blog posts in a single request.
    - Introduces `getBulkCounts` for the API call to the telemetry service.
    - Modifies `initTelemetry` to call `hydrateSummaryCounts` after `hydrateCounts`.
- **`view/component_blog_post.templ`**:
    - Adds `data-summary-url`, `data-summary-view-count`, and `data-summary-like-count` attributes to blog post summary elements.
    - Updates styling to use the new `mt-4` class.

This change improves performance by reducing the number of individual telemetry requests for list pages.